### PR TITLE
HCL Syntax Updates

### DIFF
--- a/terraform-ansible-aws/F5_Standalone_1Nic/terraform/aws_F5_standalone_1nic/main.tf
+++ b/terraform-ansible-aws/F5_Standalone_1Nic/terraform/aws_F5_standalone_1nic/main.tf
@@ -18,7 +18,7 @@ data "aws_ami" "f5_ami" {
 data "template_file" "f5_bigip_onboard" {
   template = "${file("./templates/f5_onboard.tpl")}"
 
-  vars {
+  vars = {
     DO_URL          = "${var.DO_URL}"
     AS3_URL		      = "${var.AS3_URL}"
     libs_dir		    = "${var.libs_dir}"
@@ -41,7 +41,7 @@ resource "aws_instance" "f5_bigip1" {
     delete_on_termination       = true
   }
   user_data                     = "${data.template_file.f5_bigip_onboard.rendered}"
-  tags {
+  tags = {
     Name                        = "${var.owner}-f5_bigip1"
   }
 }

--- a/terraform-ansible-aws/F5_Standalone_1Nic/terraform/aws_ubuntu_systems/main.tf
+++ b/terraform-ansible-aws/F5_Standalone_1Nic/terraform/aws_ubuntu_systems/main.tf
@@ -25,7 +25,7 @@ resource "aws_instance" "ubuntu_instance_az1" {
   instance_type = "t2.micro"
   associate_public_ip_address   = true
   vpc_security_group_ids        = ["${aws_security_group.ubuntu_sg.id}"]
-  tags {
+  tags = {
     Name                        = "${var.owner}-${var.ubuntu_instance_name}-az1-${format("%02d", count.index+1)}"
     Environmnent                = "${var.owner}"
     Application                 = "${var.app_tag_value}"
@@ -40,7 +40,7 @@ resource "aws_instance" "ubuntu_instance_az2" {
   instance_type                 = "t2.micro"
   associate_public_ip_address   = true
   vpc_security_group_ids        = ["${aws_security_group.ubuntu_sg.id}"]
-  tags {
+  tags = {
     Name                        = "${var.owner}-${var.ubuntu_instance_name}-az2-${format("%02d", count.index+1)}"
     Environmnent                = "${var.owner}"
     Application                 = "${var.app_tag_value}"

--- a/terraform-ansible-aws/F5_Standalone_1Nic/terraform/aws_ubuntu_systems/system-sg.tf
+++ b/terraform-ansible-aws/F5_Standalone_1Nic/terraform/aws_ubuntu_systems/system-sg.tf
@@ -38,7 +38,7 @@ resource "aws_security_group" "ubuntu_sg" {
         cidr_blocks = ["0.0.0.0/0"] 
     }
 
-    tags {
+    tags = {
         Name = "${var.ubuntu_instance_name}_sg"
     }
 }

--- a/terraform-ansible-aws/F5_Standalone_1Nic/terraform/aws_vpc/main.tf
+++ b/terraform-ansible-aws/F5_Standalone_1Nic/terraform/aws_vpc/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 resource "aws_vpc" "default" {
   cidr_block = "${var.vpc_cidr}"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "${var.owner}-VPC"
   }
 }
@@ -15,7 +15,7 @@ resource "aws_subnet" "public-subnet1" {
   cidr_block = "${var.public_subnet1_cidr}"
   availability_zone = "${var.aws_az1}"
 
-  tags {
+  tags = {
     Name = "${var.owner}-public-subnet1"
   }
 }
@@ -25,7 +25,7 @@ resource "aws_subnet" "public-subnet2" {
   cidr_block = "${var.public_subnet2_cidr}"
   availability_zone = "${var.aws_az2}"
 
-  tags {
+  tags = {
     Name = "${var.owner}-public-subnet2"
   }
 }
@@ -35,7 +35,7 @@ resource "aws_subnet" "private-subnet1" {
   cidr_block = "${var.private_subnet1_cidr}"
   availability_zone = "${var.aws_az1}"
 
-  tags {
+  tags = {
     Name = "${var.owner}-private-subnet1"
   }
 }
@@ -46,14 +46,14 @@ resource "aws_subnet" "private-subnet2" {
   cidr_block = "${var.private_subnet2_cidr}"
   availability_zone = "${var.aws_az2}"
 
-  tags {
+  tags = {
     Name = "${var.owner}-private-subnet2"
   }
 }
 
 resource "aws_internet_gateway" "internet-gw" {
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
     Name = "${var.owner}-InternetGw"
   }
 }
@@ -65,7 +65,7 @@ resource "aws_route_table" "public-route-table" {
     gateway_id = "${aws_internet_gateway.internet-gw.id}"
   }
 
-  tags {
+  tags = {
     Name = "${var.owner}-Public-RouteTable"
   }
 }

--- a/terraform-ansible-aws/F5_Standalone_1Nic/terraform/main.tf
+++ b/terraform-ansible-aws/F5_Standalone_1Nic/terraform/main.tf
@@ -42,10 +42,10 @@ module "aws_ubuntu_systems" {
 
 data  "template_file" "ansible_inventory" {
     template = "${file("./templates/ansible_inventory.tpl")}"
-    vars {
+    vars = {
         aws_F5_public_ip  = "${module.aws_f5_standalone.f5_public_ip}" 
         aws_F5_private_ip = "${module.aws_f5_standalone.f5_private_ip}"
-        aws_ubuntu_data   = "${join("\n", "${module.aws_ubuntu_systems.ubuntu_public_ips}")}"
+        aws_ubuntu_data   = "${join("\n", flatten("${module.aws_ubuntu_systems.ubuntu_public_ips}"))}"
     }
 }
 resource "local_file" "ansible_inventory_file" {
@@ -55,7 +55,7 @@ resource "local_file" "ansible_inventory_file" {
 
 data  "template_file" "ansible_f5_vars" {
     template = "${file("./templates/ansible_f5_vars.tpl")}"
-    vars {
+    vars = {
       aws_tag_value  = "${var.app_tag_value}"
     }
 }

--- a/terraform-ansible-azure/F5_Standalone_1Nic/terraform/azure_F5_standalone_1nic/main.tf
+++ b/terraform-ansible-azure/F5_Standalone_1Nic/terraform/azure_F5_standalone_1nic/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_public_ip" "bigip1_public_ip" {
   resource_group_name       = "${var.azure_rg_name}"
   allocation_method         = "Dynamic"
 
-  tags {
+  tags = {
     Name           = "${var.owner}-bigip1-public-ip"
     owner          = "${var.owner}"
   }
@@ -26,7 +26,7 @@ resource "azurerm_network_interface" "bigip1_nic" {
     public_ip_address_id          = "${azurerm_public_ip.bigip1_public_ip.id}"
   }
 
-  tags {
+  tags = {
     Name           = "${var.owner}-bigip1-mgmt-nic"
     owner          = "${var.owner}"
   }
@@ -36,7 +36,7 @@ resource "azurerm_network_interface" "bigip1_nic" {
 data "template_file" "f5_bigip_onboard" {
   template = "${file("./templates/f5_onboard.tpl")}"
 
-  vars {
+  vars = {
     DO_URL          = "${var.DO_URL}"
     AS3_URL		      = "${var.AS3_URL}"
     libs_dir		    = "${var.libs_dir}"
@@ -97,7 +97,7 @@ resource "azurerm_virtual_machine" "f5-bigip1" {
     product       = "${var.f5_product_name}"
   }
 
-  tags {
+  tags = {
     Name           = "${var.owner}-f5bigip1"
     owner          = "${var.owner}"
   }
@@ -123,7 +123,7 @@ resource "azurerm_virtual_machine_extension" "f5-bigip1-run-startup-cmd" {
     }
   SETTINGS
 
-  tags {
+  tags = {
     Name           = "${var.owner}-f5-bigip1-startup-cmd"
     owner          = "${var.owner}"
   }

--- a/terraform-ansible-azure/F5_Standalone_1Nic/terraform/azure_F5_standalone_1nic/security-group.tf
+++ b/terraform-ansible-azure/F5_Standalone_1Nic/terraform/azure_F5_standalone_1nic/security-group.tf
@@ -68,7 +68,7 @@ resource "azurerm_network_security_group" "bigip_sg" {
     destination_address_prefix = "*"
   }
 
-  tags {
+  tags = {
     Name           = "${var.owner}-bigip-sg"
     owner          = "${var.owner}"
   }

--- a/terraform-ansible-azure/F5_Standalone_1Nic/terraform/azure_ressourcegroup/main.tf
+++ b/terraform-ansible-azure/F5_Standalone_1Nic/terraform/azure_ressourcegroup/main.tf
@@ -1,7 +1,7 @@
 resource "azurerm_resource_group" "azure_rg" {
   name = "${var.owner}-RG"
   location = "${var.azure_region}"
-  tags {
+  tags = {
     environment = "${var.owner}"
   }
 }
@@ -12,7 +12,7 @@ resource "azurerm_virtual_network" "azurerm_virtualnet" {
     location            = "${var.azure_region}"
     resource_group_name = "${azurerm_resource_group.azure_rg.name}"
 
-    tags {
+    tags = {
         environment = "Terraform Demo"
     }
 }

--- a/terraform-ansible-azure/F5_Standalone_1Nic/terraform/azure_ubuntu_systems/main.tf
+++ b/terraform-ansible-azure/F5_Standalone_1Nic/terraform/azure_ubuntu_systems/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_public_ip" "ubuntu_az1_publicips" {
     allocation_method            = "Static"
     zones                        = ["${var.ubuntu_subnet_id_az1}"]
 
-    tags {
+    tags = {
         environment = "${var.owner}"
     }
 }
@@ -20,7 +20,7 @@ resource "azurerm_public_ip" "ubuntu_az2_publicips" {
     allocation_method            = "Static"
     zones                        = ["${var.ubuntu_subnet_id_az2}"]
 
-    tags {
+    tags = {
         environment = "${var.owner}"
     }
 }
@@ -39,7 +39,7 @@ resource "azurerm_network_interface" "ubuntu_az1_privatenics" {
         public_ip_address_id          = "${element(azurerm_public_ip.ubuntu_az1_publicips.*.id, count.index)}"
     }
 
-    tags {
+    tags = {
         environment = "${var.owner}"
     }
 }
@@ -58,7 +58,7 @@ resource "azurerm_network_interface" "ubuntu_az2_privatenics" {
         public_ip_address_id          = "${element(azurerm_public_ip.ubuntu_az2_publicips.*.id, count.index)}"
     }
 
-    tags {
+    tags = {
         environment = "${var.owner}"
     }
 }
@@ -81,7 +81,7 @@ resource "azurerm_storage_account" "azure_storage_account" {
     account_replication_type = "LRS"
     account_tier = "Standard"
 
-    tags {
+    tags = {
         environment = "${var.owner}"
     }
 }
@@ -134,7 +134,7 @@ resource "azurerm_virtual_machine" "azure_az1_ubuntu_vm" {
         storage_uri = "${azurerm_storage_account.azure_storage_account.primary_blob_endpoint}"
     }
 
-    tags {
+    tags = {
         environment = "${var.owner}"
     }
 }
@@ -180,7 +180,7 @@ resource "azurerm_virtual_machine" "azure_az2_ubuntu_vm" {
         storage_uri = "${azurerm_storage_account.azure_storage_account.primary_blob_endpoint}"
     }
 
-    tags {
+    tags = {
         environment = "${var.owner}"
     }
 }

--- a/terraform-ansible-azure/F5_Standalone_1Nic/terraform/main.tf
+++ b/terraform-ansible-azure/F5_Standalone_1Nic/terraform/main.tf
@@ -51,10 +51,10 @@ module "azure_ubuntu_systems" {
 
 data  "template_file" "ansible_inventory" {
   template = "${file("./templates/ansible_inventory.tpl")}"
-  vars {
+  vars = {
     azure_F5_public_ip = "${module.azure_f5_standalone.f5_public_ip}" 
     azure_F5_private_ip = "${module.azure_f5_standalone.f5_private_ip}"
-    azure_ubuntu_data = "${join("\n", "${module.azure_ubuntu_systems.ubuntu_public_ips}")}"
+    azure_ubuntu_data = "${join("\n", flatten("${module.azure_ubuntu_systems.ubuntu_public_ips}"))}"
   }
 }
 
@@ -65,8 +65,8 @@ resource "local_file" "ansible_inventory_file" {
 
 data  "template_file" "ansible_f5_vars" {
   template = "${file("./templates/ansible_f5_vars.tpl")}"
-  vars {
-    azure_f5_pool_members = "${join("','", "${module.azure_ubuntu_systems.ubuntu_private_ips}")}"
+  vars = {
+    azure_f5_pool_members = "${join("','", flatten("${module.azure_ubuntu_systems.ubuntu_private_ips}"))}"
   }
 }
 resource "local_file" "ansible_f5_vars_file" {


### PR DESCRIPTION
nmenant/Public-Cloud-Templates fails at ``terraform plan`` for both examples. This appears to be due to HCL syntax parser changes from 0.11 to 0.12. I've updated all problematic syntax and tested ``plan``.

_Note:_ I appear to not have appropriate azure permissions so I can't ``apply`` the azure template. Please run through testing before accepting the merge. I *think* we're good but you should definitely test first. 

Current terraform binary is v0.12.9 (but v0.12.8 is still installed from homebrew).
```shell
$ terraform --version
Terraform v0.12.8
```