### PR TITLE
Hcl syntax consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ terraform.tfstate*
 f5_vault
 *.json
 site.retry
+azure_creds.sh

--- a/terraform-ansible-aws/F5_BIG-IP-Standalone_1Nic/ansible/playbooks/roles/f5_onboarding/tasks/main.yml
+++ b/terraform-ansible-aws/F5_BIG-IP-Standalone_1Nic/ansible/playbooks/roles/f5_onboarding/tasks/main.yml
@@ -7,7 +7,7 @@
       ssh_keyfile: "{{ SSH_KEY_PATH }}"
       transport: cli
       user: admin
-    commands: modify auth user admin password {{ ADMIN_PASSWORD }}
+    commands: modify auth user admin password {{ ADMIN_PASSWORD | regex_replace('!', '\!') | regex_escape('posix_basic') }}
     validate_certs: no
   delegate_to: localhost
 

--- a/terraform-ansible-aws/F5_BIG-IP-Standalone_1Nic/terraform/terraform.tfvars
+++ b/terraform-ansible-aws/F5_BIG-IP-Standalone_1Nic/terraform/terraform.tfvars
@@ -14,7 +14,7 @@ aws_az2 = "eu-west-1c"
 #F5 Image to deploy
 f5_name_filter = "F5*BIGIP-14.1* PAYG*-*Best 200Mbps*"
 #Public key to use to access the instances
-key_path = "/Users/menant/.ssh/id_rsa.pub"
+key_path = "~/.ssh/id_rsa.pub"
 
 #Public IPs used to access your instances
 AllowedIPs = ["109.7.65.101/32","109.7.65.102/32"]

--- a/terraform-ansible-aws/terraform_modules/aws_F5_standalone_1nic/main.tf
+++ b/terraform-ansible-aws/terraform_modules/aws_F5_standalone_1nic/main.tf
@@ -16,7 +16,7 @@ data "aws_ami" "f5_ami" {
 
 # Data resource to create the user_data script
 data "template_file" "f5_bigip_onboard" {
-  template = "${file("./templates/f5_onboard.tpl")}"
+  template = file("./templates/f5_onboard.tpl")
 
   vars = {
     DO_URL          = var.DO_URL
@@ -40,7 +40,7 @@ resource "aws_instance" "f5_bigip1" {
   root_block_device {
     delete_on_termination       = true
   }
-  user_data                     = "${data.template_file.f5_bigip_onboard.rendered}"
+  user_data                     = data.template_file.f5_bigip_onboard.rendered
   tags = {
     Name                        = "${var.owner}-f5_bigip1"
   }

--- a/terraform-ansible-aws/terraform_modules/aws_F5_standalone_1nic/security-groups.tf
+++ b/terraform-ansible-aws/terraform_modules/aws_F5_standalone_1nic/security-groups.tf
@@ -13,8 +13,8 @@ resource "aws_security_group" "f5_bigip_sg" {
 
   # MGMT
   ingress {
-    from_port   = "${var.bigip_https_port}"
-    to_port     = "${var.bigip_https_port}"
+    from_port   = var.bigip_https_port
+    to_port     = var.bigip_https_port
     protocol    = "tcp"
     cidr_blocks = var.AllowedIPs
   }

--- a/terraform-ansible-aws/terraform_modules/aws_ubuntu_systems/outputs.tf
+++ b/terraform-ansible-aws/terraform_modules/aws_ubuntu_systems/outputs.tf
@@ -1,9 +1,9 @@
 
 output "ubuntu_public_ips" {
-  value = "${concat(aws_instance.ubuntu_instance_az1[*].public_ip, aws_instance.ubuntu_instance_az2[*].public_ip)}"
+  value = concat(aws_instance.ubuntu_instance_az1[*].public_ip, aws_instance.ubuntu_instance_az2[*].public_ip)
 }
 
 
 output "ubuntu_private_ips" {
-  value = "${concat(aws_instance.ubuntu_instance_az1[*].private_ip, aws_instance.ubuntu_instance_az2[*].private_ip)}"
+  value = concat(aws_instance.ubuntu_instance_az1[*].private_ip, aws_instance.ubuntu_instance_az2[*].private_ip)
 }

--- a/terraform-ansible-aws/terraform_modules/aws_ubuntu_systems/security-groups.tf
+++ b/terraform-ansible-aws/terraform_modules/aws_ubuntu_systems/security-groups.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "ubuntu_sg" {
     name = "${var.ubuntu_instance_name}_sg"
-    vpc_id = "${var.vpc_id}"
+    vpc_id = var.vpc_id
     description = "Accept incoming connections."
 
     ingress {
@@ -14,7 +14,7 @@ resource "aws_security_group" "ubuntu_sg" {
         from_port       = 80
         to_port         = 80
         protocol        = "tcp"
-        cidr_blocks     = ["${var.public_subnet1_cidr}","${var.public_subnet2_cidr}","${var.private_subnet1_cidr}","${var.private_subnet2_cidr}"] 
+        cidr_blocks     = [var.public_subnet1_cidr, var.public_subnet2_cidr, var.private_subnet1_cidr, var.private_subnet2_cidr] 
     }
 
     ingress {
@@ -28,7 +28,7 @@ resource "aws_security_group" "ubuntu_sg" {
         from_port       = 443
         to_port         = 443
         protocol        = "tcp"
-        cidr_blocks     = ["${var.public_subnet1_cidr}","${var.public_subnet2_cidr}","${var.private_subnet1_cidr}","${var.private_subnet2_cidr}"]  
+        cidr_blocks     = [var.public_subnet1_cidr, var.public_subnet2_cidr, var.private_subnet1_cidr, var.private_subnet2_cidr]  
     }
 
     ingress {
@@ -42,7 +42,7 @@ resource "aws_security_group" "ubuntu_sg" {
         from_port       = 22
         to_port         = 22
         protocol        = "tcp"
-        cidr_blocks     = ["${var.public_subnet1_cidr}","${var.public_subnet2_cidr}","${var.private_subnet1_cidr}","${var.private_subnet2_cidr}"]  
+        cidr_blocks     = [var.public_subnet1_cidr, var.public_subnet2_cidr, var.private_subnet1_cidr, var.private_subnet2_cidr]  
     }
 
     ingress {
@@ -56,7 +56,7 @@ resource "aws_security_group" "ubuntu_sg" {
         from_port       = -1
         to_port         = -1
         protocol        = "icmp"
-        cidr_blocks     = ["${var.public_subnet1_cidr}","${var.public_subnet2_cidr}","${var.private_subnet1_cidr}","${var.private_subnet2_cidr}"]  
+        cidr_blocks     = [var.public_subnet1_cidr, var.public_subnet2_cidr, var.private_subnet1_cidr, var.private_subnet2_cidr]  
     }
 
     egress {

--- a/terraform-ansible-aws/terraform_modules/aws_vpc/main.tf
+++ b/terraform-ansible-aws/terraform_modules/aws_vpc/main.tf
@@ -94,5 +94,5 @@ resource "aws_route_table_association" "private2-rt" {
 
 resource "aws_key_pair" "default" {
   key_name        = "${var.owner}-KeyPair"
-  public_key      = "${file("${var.key_path}")}"
+  public_key      = file(pathexpand(var.key_path))
 }

--- a/terraform-ansible-azure/F5_BIG-IP_Standalone_1Nic/ansible/playbooks/roles/f5_onboarding/tasks/main.yml
+++ b/terraform-ansible-azure/F5_BIG-IP_Standalone_1Nic/ansible/playbooks/roles/f5_onboarding/tasks/main.yml
@@ -7,7 +7,7 @@
       ssh_keyfile: "{{ SSH_KEY_PATH }}"
       transport: cli
       user: admin
-    commands: modify auth user admin password {{ ADMIN_PASSWORD }}
+    commands: modify auth user admin password {{ ADMIN_PASSWORD | regex_replace('!', '\!') | regex_escape('posix_basic') }}
     validate_certs: no
   delegate_to: localhost
 

--- a/terraform-ansible-azure/F5_BIG-IP_Standalone_1Nic/terraform/terraform.tfvars
+++ b/terraform-ansible-azure/F5_BIG-IP_Standalone_1Nic/terraform/terraform.tfvars
@@ -4,10 +4,10 @@ owner = "NicoM"
 #Name of the project
 project_name = "TestTerraform"
 
-#AWS Region to use
+#Azure Region to use
 azure_region = "francecentral"
 
-#AWS AZ to use. Need 2
+#Azure AZ to use. Need 2
 azure_az1 = "1"
 azure_az2 = "2"
 

--- a/terraform-ansible-azure/terraform_modules/azure_F5_standalone_1nic/outputs.tf
+++ b/terraform-ansible-azure/terraform_modules/azure_F5_standalone_1nic/outputs.tf
@@ -1,10 +1,10 @@
 output "f5_public_ip" {
-  value = "${data.azurerm_public_ip.bigip1-public-ip.ip_address}"
+  value = data.azurerm_public_ip.bigip1-public-ip.ip_address
 }
 
 output "f5_private_ip" {
-  value = "${azurerm_network_interface.bigip1_nic.private_ip_address}"
+  value = azurerm_network_interface.bigip1_nic.private_ip_address
 }
 output "f5_username" {
-  value = "${var.f5_username}"
+  value = var.f5_username
 }

--- a/terraform-ansible-azure/terraform_modules/azure_F5_standalone_1nic/security-group.tf
+++ b/terraform-ansible-azure/terraform_modules/azure_F5_standalone_1nic/security-group.tf
@@ -1,7 +1,7 @@
 resource "azurerm_network_security_group" "bigip_sg" {
   name                = "${var.owner}-bigip-sg"
-  location            = "${var.azure_region}"
-  resource_group_name = "${var.azure_rg_name}"
+  location            = var.azure_region
+  resource_group_name = var.azure_rg_name
 
   security_rule {
     name                       = "allow_SSH"
@@ -70,6 +70,6 @@ resource "azurerm_network_security_group" "bigip_sg" {
 
   tags = {
     Name           = "${var.owner}-bigip-sg"
-    owner          = "${var.owner}"
+    owner          = var.owner
   }
 }

--- a/terraform-ansible-azure/terraform_modules/azure_ressourcegroup/main.tf
+++ b/terraform-ansible-azure/terraform_modules/azure_ressourcegroup/main.tf
@@ -1,16 +1,16 @@
 resource "azurerm_resource_group" "azure_rg" {
   name = "${var.owner}-RG"
-  location = "${var.azure_region}"
+  location = var.azure_region
   tags = {
-    environment = "${var.owner}"
+    environment = var.owner
   }
 }
 
 resource "azurerm_virtual_network" "azurerm_virtualnet" {
     name                = "${var.owner}-VNet"
-    address_space       = ["${var.azure_rg_cidr}"]
-    location            = "${var.azure_region}"
-    resource_group_name = "${azurerm_resource_group.azure_rg.name}"
+    address_space       = [var.azure_rg_cidr]
+    location            = var.azure_region
+    resource_group_name = azurerm_resource_group.azure_rg.name
 
     tags = {
         environment = "Terraform Demo"
@@ -19,15 +19,15 @@ resource "azurerm_virtual_network" "azurerm_virtualnet" {
 
 resource "azurerm_subnet" "azurerm_publicsubnet1" {
     name                 = "${var.owner}-publicsubnet1"
-    resource_group_name  = "${azurerm_resource_group.azure_rg.name}"
-    virtual_network_name = "${azurerm_virtual_network.azurerm_virtualnet.name}"
-    address_prefix       = "${var.public_subnet1_cidr}"
+    resource_group_name  = azurerm_resource_group.azure_rg.name
+    virtual_network_name = azurerm_virtual_network.azurerm_virtualnet.name
+    address_prefix       = var.public_subnet1_cidr
 }
 
 resource "azurerm_subnet" "azurerm_privatesubnet1" {
     name                 = "${var.owner}-privatesubnet1"
-    resource_group_name  = "${azurerm_resource_group.azure_rg.name}"
-    virtual_network_name = "${azurerm_virtual_network.azurerm_virtualnet.name}"
-    address_prefix       = "${var.private_subnet1_cidr}"
+    resource_group_name  = azurerm_resource_group.azure_rg.name
+    virtual_network_name = azurerm_virtual_network.azurerm_virtualnet.name
+    address_prefix       = var.private_subnet1_cidr
 }
 

--- a/terraform-ansible-azure/terraform_modules/azure_ressourcegroup/outputs.tf
+++ b/terraform-ansible-azure/terraform_modules/azure_ressourcegroup/outputs.tf
@@ -1,19 +1,19 @@
 
 output "azure_rg_name" {
-  value = "${azurerm_resource_group.azure_rg.name}"
+  value = azurerm_resource_group.azure_rg.name
 }
 
 output "network_name" {
-  value = "${azurerm_virtual_network.azurerm_virtualnet.name}"
+  value = azurerm_virtual_network.azurerm_virtualnet.name
 }
 output "public_subnet1_name" {
-  value = "${azurerm_subnet.azurerm_publicsubnet1.name}"
+  value = azurerm_subnet.azurerm_publicsubnet1.name
 }
 output "public_subnet1_id" {
-  value = "${azurerm_subnet.azurerm_publicsubnet1.id}"
+  value = azurerm_subnet.azurerm_publicsubnet1.id
 }
 output "public_subnet1_cidr" {
-  value = "${var.public_subnet1_cidr}"
+  value = var.public_subnet1_cidr
 }
 #output "public_subnet2_id" {
 #  value = "${aws_subnet.public-subnet2.id}"
@@ -22,10 +22,10 @@ output "public_subnet1_cidr" {
 #  value = "${var.public_subnet2_cidr}"
 #}
 output "private_subnet1_id" {
-  value = "${azurerm_subnet.azurerm_privatesubnet1.id}"
+  value = azurerm_subnet.azurerm_privatesubnet1.id
 }
 output "private_subnet1_cidr" {
-  value = "${var.private_subnet1_cidr}"
+  value = var.private_subnet1_cidr
 }
 #output "private_subnet2_id" {
 #  value = "${aws_subnet.private-subnet2.id}"

--- a/terraform-ansible-azure/terraform_modules/azure_ubuntu_systems/main.tf
+++ b/terraform-ansible-azure/terraform_modules/azure_ubuntu_systems/main.tf
@@ -1,11 +1,11 @@
 
 resource "azurerm_public_ip" "ubuntu_az1_publicips" {
-    count                        = "${var.ubuntu_instance_count}"
+    count                        = var.ubuntu_instance_count
     name                         = "${var.owner}-${var.ubuntu_instance_name}-az1-public-ip-${format("%02d", count.index+1)}"
-    location                     = "${var.azure_region}"
-    resource_group_name          = "${var.azure_rg_name}"
+    location                     = var.azure_region
+    resource_group_name          = var.azure_rg_name
     allocation_method            = "Static"
-    zones                        = ["${var.ubuntu_subnet_id_az1}"]
+    zones                        = [var.ubuntu_subnet_id_az1]
 
     tags = {
         environment = "${var.owner}"
@@ -13,53 +13,53 @@ resource "azurerm_public_ip" "ubuntu_az1_publicips" {
 }
 
 resource "azurerm_public_ip" "ubuntu_az2_publicips" {
-    count                        = "${var.ubuntu_instance_count}"
+    count                        = var.ubuntu_instance_count
     name                         = "${var.owner}-${var.ubuntu_instance_name}-az2-public-ip-${format("%02d", count.index+1)}"
-    location                     = "${var.azure_region}"
-    resource_group_name          = "${var.azure_rg_name}"
+    location                     = var.azure_region
+    resource_group_name          = var.azure_rg_name
     allocation_method            = "Static"
-    zones                        = ["${var.ubuntu_subnet_id_az2}"]
+    zones                        = [var.ubuntu_subnet_id_az2]
 
     tags = {
-        environment = "${var.owner}"
+        environment = var.owner
     }
 }
 
 resource "azurerm_network_interface" "ubuntu_az1_privatenics" {
-    count                         = "${var.ubuntu_instance_count}"
+    count                         = var.ubuntu_instance_count
     name                          = "${var.owner}-${var.ubuntu_instance_name}-az1-private-nic-${format("%02d", count.index+1)}"
-    location                      = "${var.azure_region}"
-    resource_group_name           = "${var.azure_rg_name}"
-    network_security_group_id     = "${azurerm_network_security_group.azure_ubuntu_sg.id}"
+    location                      = var.azure_region
+    resource_group_name           = var.azure_rg_name
+    network_security_group_id     = azurerm_network_security_group.azure_ubuntu_sg.id
 
     ip_configuration {
         name                          = "${var.owner}-${var.ubuntu_instance_name}-az1-private-ip-${format("%02d", count.index+1)}"
-        subnet_id                     = "${var.private_subnet1_id}"
+        subnet_id                     = var.private_subnet1_id
         private_ip_address_allocation = "Dynamic"
-        public_ip_address_id          = "${element(azurerm_public_ip.ubuntu_az1_publicips.*.id, count.index)}"
+        public_ip_address_id          = element(azurerm_public_ip.ubuntu_az1_publicips.*.id, count.index)
     }
 
     tags = {
-        environment = "${var.owner}"
+        environment = var.owner
     }
 }
 
 resource "azurerm_network_interface" "ubuntu_az2_privatenics" {
-    count                         = "${var.ubuntu_instance_count}"
+    count                         = var.ubuntu_instance_count
     name                          = "${var.owner}-${var.ubuntu_instance_name}-az2-private-nic-${format("%02d", count.index+1)}"
-    location                      = "${var.azure_region}"
-    resource_group_name           = "${var.azure_rg_name}"
-    network_security_group_id     = "${azurerm_network_security_group.azure_ubuntu_sg.id}"
+    location                      = var.azure_region
+    resource_group_name           = var.azure_rg_name
+    network_security_group_id     = azurerm_network_security_group.azure_ubuntu_sg.id
 
     ip_configuration {
         name                          = "${var.owner}-${var.ubuntu_instance_name}-az2-private-ip-${format("%02d", count.index+1)}"
-        subnet_id                     = "${var.private_subnet1_id}"
+        subnet_id                     = var.private_subnet1_id
         private_ip_address_allocation = "Dynamic"
-        public_ip_address_id          = "${element(azurerm_public_ip.ubuntu_az2_publicips.*.id, count.index)}"
+        public_ip_address_id          = element(azurerm_public_ip.ubuntu_az2_publicips.*.id, count.index)
     }
 
     tags = {
-        environment = "${var.owner}"
+        environment = var.owner
     }
 }
 
@@ -69,31 +69,31 @@ resource "azurerm_network_interface" "ubuntu_az2_privatenics" {
 resource "random_id" "randomId" {
     keepers = {
         # Generate a new ID only when a new resource group is defined
-        resource_group = "${var.azure_rg_name}"
+        resource_group = var.azure_rg_name
     }
     
     byte_length = 8
 }
 resource "azurerm_storage_account" "azure_storage_account" {
     name                = "diag${random_id.randomId.hex}"
-    resource_group_name = "${var.azure_rg_name}"
-    location            = "${var.azure_region}"
+    resource_group_name = var.azure_rg_name
+    location            = var.azure_region
     account_replication_type = "LRS"
     account_tier = "Standard"
 
     tags = {
-        environment = "${var.owner}"
+        environment = var.owner
     }
 }
 
 resource "azurerm_virtual_machine" "azure_az1_ubuntu_vm" {
-    count                 = "${var.ubuntu_instance_count}"
+    count                 = var.ubuntu_instance_count
     name                  = "${var.owner}-ubuntu-NGINX-az1-${format("%02d", count.index+1)}"
-    location              = "${var.azure_region}"
-    resource_group_name   = "${var.azure_rg_name}"
-    network_interface_ids = ["${element(azurerm_network_interface.ubuntu_az1_privatenics.*.id, count.index)}"]
-    vm_size               = "${var.ubuntu_instance_size}"
-    zones                  = ["${var.ubuntu_subnet_id_az1}"]
+    location              = var.azure_region
+    resource_group_name   = var.azure_rg_name
+    network_interface_ids = [element(azurerm_network_interface.ubuntu_az1_privatenics.*.id, count.index)]
+    vm_size               = var.ubuntu_instance_size
+    zones                  = [var.ubuntu_subnet_id_az1]
 
     # Uncomment this line to delete the OS disk automatically when deleting the VM
     delete_os_disk_on_termination = true
@@ -118,36 +118,36 @@ resource "azurerm_virtual_machine" "azure_az1_ubuntu_vm" {
 
     os_profile {
         computer_name  = "${var.owner}-ubuntu-NGINX-az1-${format("%02d", count.index+1)}"
-        admin_username = "${var.ubuntu_username}"
+        admin_username = var.ubuntu_username
     }
 
     os_profile_linux_config {
         disable_password_authentication = true
         ssh_keys {
             path     = "/home/azureuser/.ssh/authorized_keys"
-            key_data = "${var.public_key}"
+            key_data = var.public_key
         }
     }
 
     boot_diagnostics {
         enabled     = "true"
-        storage_uri = "${azurerm_storage_account.azure_storage_account.primary_blob_endpoint}"
+        storage_uri = azurerm_storage_account.azure_storage_account.primary_blob_endpoint
     }
 
     tags = {
-        environment = "${var.owner}"
-        Application = "${var.app_tag_value}"
+        environment = var.owner
+        Application = var.app_tag_value
     }
 }
 
 resource "azurerm_virtual_machine" "azure_az2_ubuntu_vm" {
-    count                 = "${var.ubuntu_instance_count}"
+    count                 = var.ubuntu_instance_count
     name                  = "${var.owner}-ubuntu-NGINX-az2-${format("%02d", count.index+1)}"
-    location              = "${var.azure_region}"
-    resource_group_name   = "${var.azure_rg_name}"
-    network_interface_ids = ["${element(azurerm_network_interface.ubuntu_az2_privatenics.*.id, count.index)}"]
-    vm_size               = "${var.ubuntu_instance_size}"
-    zones                  = ["${var.ubuntu_subnet_id_az2}"]
+    location              = var.azure_region
+    resource_group_name   = var.azure_rg_name
+    network_interface_ids = [element(azurerm_network_interface.ubuntu_az2_privatenics.*.id, count.index)]
+    vm_size               = var.ubuntu_instance_size
+    zones                  = [var.ubuntu_subnet_id_az2]
 
     storage_os_disk {
         name              = "${var.owner}-ubuntu-NGINX-Disk-az2${format("%02d", count.index+1)}"
@@ -172,17 +172,17 @@ resource "azurerm_virtual_machine" "azure_az2_ubuntu_vm" {
         disable_password_authentication = true
         ssh_keys {
             path     = "/home/azureuser/.ssh/authorized_keys"
-            key_data = "${var.public_key}"
+            key_data = var.public_key
         }
     }
 
     boot_diagnostics {
         enabled     = "true"
-        storage_uri = "${azurerm_storage_account.azure_storage_account.primary_blob_endpoint}"
+        storage_uri = azurerm_storage_account.azure_storage_account.primary_blob_endpoint
     }
 
     tags = {
-        environment = "${var.owner}"
-        Application = "${var.app_tag_value}"
+        environment = var.owner
+        Application = var.app_tag_value
     }
 }

--- a/terraform-ansible-azure/terraform_modules/azure_ubuntu_systems/outputs.tf
+++ b/terraform-ansible-azure/terraform_modules/azure_ubuntu_systems/outputs.tf
@@ -1,8 +1,8 @@
 
 output "ubuntu_public_ips" {
-  value = "${concat(azurerm_public_ip.ubuntu_az1_publicips[*].ip_address, azurerm_public_ip.ubuntu_az2_publicips[*].ip_address)}"
+  value = concat(azurerm_public_ip.ubuntu_az1_publicips[*].ip_address, azurerm_public_ip.ubuntu_az2_publicips[*].ip_address)
 }
 
 output "ubuntu_private_ips" {
-  value = "${concat(azurerm_network_interface.ubuntu_az1_privatenics[*].private_ip_address, azurerm_network_interface.ubuntu_az2_privatenics[*].private_ip_address)}"
+  value = concat(azurerm_network_interface.ubuntu_az1_privatenics[*].private_ip_address, azurerm_network_interface.ubuntu_az2_privatenics[*].private_ip_address)
 }

--- a/terraform-ansible-azure/terraform_modules/azure_ubuntu_systems/security-group.tf
+++ b/terraform-ansible-azure/terraform_modules/azure_ubuntu_systems/security-group.tf
@@ -1,7 +1,7 @@
 resource "azurerm_network_security_group" "azure_ubuntu_sg" {
     name                = "${var.owner}-ubuntu-SG"
-    location            = "${var.azure_region}"
-    resource_group_name = "${var.azure_rg_name}"
+    location            = var.azure_region
+    resource_group_name = var.azure_rg_name
     
     security_rule {
         name                       = "SSH_From_Outside"
@@ -23,7 +23,7 @@ resource "azurerm_network_security_group" "azure_ubuntu_sg" {
         protocol                   = "Tcp"
         source_port_range          = "*"
         destination_port_range     = "22"
-        source_address_prefixes    = ["${var.public_subnet1_cidr}","${var.private_subnet1_cidr}"]  
+        source_address_prefixes    = [var.public_subnet1_cidr, var.private_subnet1_cidr]  
         destination_address_prefix = "*"
     }
 
@@ -47,7 +47,7 @@ resource "azurerm_network_security_group" "azure_ubuntu_sg" {
         protocol                   = "Tcp"
         source_port_range          = "*"
         destination_port_range     = "80"
-        source_address_prefixes    = ["${var.public_subnet1_cidr}","${var.private_subnet1_cidr}"]
+        source_address_prefixes    = [var.public_subnet1_cidr, var.private_subnet1_cidr]
         destination_address_prefix = "*"
     }
 
@@ -71,7 +71,7 @@ resource "azurerm_network_security_group" "azure_ubuntu_sg" {
         protocol                   = "Tcp"
         source_port_range          = "*"
         destination_port_range     = "443"
-        source_address_prefixes    = ["${var.public_subnet1_cidr}","${var.private_subnet1_cidr}"]  
+        source_address_prefixes    = [var.public_subnet1_cidr, var.private_subnet1_cidr]  
         destination_address_prefix = "*"
     }
 }

--- a/terraform-ansible-vmware/F5_BIG-IP-Standalone_1Nic/ansible/playbooks/roles/f5_onboarding/tasks/main.yml
+++ b/terraform-ansible-vmware/F5_BIG-IP-Standalone_1Nic/ansible/playbooks/roles/f5_onboarding/tasks/main.yml
@@ -1,10 +1,23 @@
 ---
 
-- name: change default admin password
-  command: tmsh modify auth user admin password {{ ADMIN_PASSWORD }}
+- name: Set BIG-IP admin password
+  bigip_command:
+    provider:
+      server: "{{ inventory_hostname }}"
+      ssh_keyfile: "{{ SSH_KEY_PATH }}"
+      transport: cli
+      user: admin
+    commands: modify auth user admin password {{ ADMIN_PASSWORD | regex_replace('!', '\!') | regex_escape('posix_basic') }}
+    validate_certs: no
+  delegate_to: localhost
 
-- name: change default root password
-  command: tmsh modify auth user root password {{ ADMIN_PASSWORD }}
-
-- name: enable iApps LX GUI
-  command: touch /var/config/rest/iapps/enable
+- name: enable iApps LX Package management in UI
+  bigip_command:
+    provider:
+      server: "{{ inventory_hostname }}"
+      ssh_keyfile: "{{ SSH_KEY_PATH }}"
+      transport: cli
+      user: admin
+    commands: run /util bash -c "touch /var/config/rest/iapps/enable"
+    validate_certs: no
+  delegate_to: localhost

--- a/terraform-ansible-vmware/terraform_modules/vmware_F5_standalone_1nic/main.tf
+++ b/terraform-ansible-vmware/terraform_modules/vmware_F5_standalone_1nic/main.tf
@@ -21,7 +21,7 @@ data "vsphere_datastore" "f5_datastore" {
 }
 
 data "template_file" "f5_bigip_onboard" {
-  template = "${file("./templates/f5_onboard.tpl")}"
+  template = file("../../F5_BIG-IP-Standalone_1Nic/templates/f5_onboard.tpl")
 
   vars = {
     DO_URL          = var.DO_URL


### PR DESCRIPTION
# Branch Overview

* I've made the HCL syntax consistent (and pegged to v0.12) across the project
* Made ssh key used contingent on the user via pathexpand()
* Updated the f5 onboarding role so it will now work with passwords that contain bash control characters. 

# Stability

VMware pieces can't be validated until we put some more work (provider dependencies, playbooks are placeholder, etc. -- I know it's a work in progress). 

AWS and Azure pieces have been "validated", "applied" and "destroyed".