### PR TITLE
Update main.yml

### DIFF
--- a/terraform-ansible-aws/F5_BIG-IP-Standalone_1Nic/ansible/playbooks/roles/f5_onboarding/tasks/main.yml
+++ b/terraform-ansible-aws/F5_BIG-IP-Standalone_1Nic/ansible/playbooks/roles/f5_onboarding/tasks/main.yml
@@ -6,17 +6,6 @@
       ssh_keyfile: "{{ SSH_KEY_PATH }}"
       transport: cli
       user: admin
+      validate_certs: no
     commands: modify auth user admin password {{ ADMIN_PASSWORD }}
-    validate_certs: no
-  delegate_to: localhost
-
-- name: enable iApps LX Package management in UI
-  bigip_command:
-    provider:
-      server: "{{ inventory_hostname }}"
-      ssh_keyfile: "{{ SSH_KEY_PATH }}"
-      transport: cli
-      user: admin
-    commands: run /util bash -c "touch /var/config/rest/iapps/enable"
-    validate_certs: no
   delegate_to: localhost


### PR DESCRIPTION
For latest ansible versions, "validate_certs" should be within the "provider" parameter.
Also had issues trying to add additional logic that is outside of tmsh (run /util bash -c "touch /var/config/rest/iapps/enable"). Due to the BIGIP image is 14.x, consider not necessary this step.

Ref: https://docs.ansible.com/ansible/latest/modules/bigip_command_module.html